### PR TITLE
Fix '-L' option to use-package into the correct package.

### DIFF
--- a/lib/script.lisp
+++ b/lib/script.lisp
@@ -167,7 +167,8 @@
 		    ((opt :repl)
 		     (load (cim_home "/lib/repl.lisp") :verbose nil :print nil))
 		    ((opt :sexp)
-		     (let ((+eof+ (gensym "eof")))
+		     (let ((+eof+ (gensym "eof"))
+               (*package* (find-package :cl)))
                        (with-input-from-string (in (opt :sexp))
                          (loop :for sexp := (read in nil +eof+)
                             :until (eq sexp +eof+) :do


### PR DESCRIPTION
'-L' used to use-package into COMMON-LISP package, but the default package is CIM.

```
$ cl -L split-sequence -e '(split-sequence (aref "," 0) "1,2,3")'
To load "split-sequence":
  Load 1 ASDF system:
    split-sequence
; Loading "split-sequence"

; in: SPLIT-SEQUENCE (AREF "," 0)
;     (CIM::SPLIT-SEQUENCE (AREF "," 0) "1,2,3")
; 
; caught STYLE-WARNING:
;   undefined function: SPLIT-SEQUENCE
; 
; compilation unit finished
;   Undefined function:
;     SPLIT-SEQUENCE
;   caught 1 STYLE-WARNING condition
Unhandled UNDEFINED-FUNCTION in thread #<SB-THREAD:THREAD "main thread" RUNNING
                                          {1003ABF263}>:
  The function CIM::SPLIT-SEQUENCE is undefined.

Backtrace for: #<SB-THREAD:THREAD "main thread" RUNNING {1003ABF263}>
0: ("undefined function")
1: (SB-INT:SIMPLE-EVAL-IN-LEXENV (SPLIT-SEQUENCE (AREF "," 0) "1,2,3") #<NULL-LEXENV>)
2: (EVAL (SPLIT-SEQUENCE (AREF "," 0) "1,2,3"))
3: ((LAMBDA NIL :IN "/Users/nitro_idiot/.cim/lib/script.lisp"))
4: (SB-INT:SIMPLE-EVAL-IN-LEXENV (LET ((SEXPS)) (SETF *ARGV* (PARSE-OPTIONS *RAW-ARGV* (("-c" "--compile") (FILE) "compile FILE." (PUSH # SEXPS)) (("-C") (DIR) "set *default-pathname-defaults* DIR." (LET # #)) (("-d" "--debug") NIL "set debugging flags (push :debug into *features*)" (PUSH # SEXPS)) (("-e" "--eval") (SEXP) "one line of script. Several -e's are allowed. Omit [programfile]" (SETF # #)) (("-f" "--load") (FILE) "load the FILE" (PUSH # SEXPS)) (("-i") (EXT) "edit *argv* files in place and make backup with the extension .EXT" (PUSH # SEXPS)) (("-l") (LIBRARY) "quickload the LIBRARY" (PUSH # SEXPS)) (("-L") (LIBRARY) "quickload and use-package the LIBRARY" (LET # #)) (("-r" "--repl") NIL "run repl" (SETF # T)) (("-q" "--no-init") NIL "do not load $CIM_HOME/init.lisp" (SETF # T)) ...)) (IF (EQUAL *DEFAULT-PATHNAME-DEFAULTS* #P"") (SETF *DEFAULT-PATHNAME-DEFAULTS* (PATHNAME (GETENV "PWD")))) (COND ((OPT :VERSION) (WRITE-LINE (VERSION))) ((OPT :HELP) (WRITE-LINE *HELP*)) (T (UNLESS (OPT :NO-INIT) (LOAD # :VERBOSE NIL :PRINT NIL)) (IN-PACKAGE :CL) (DOLIST (SEXP #) (EVAL SEXP)) (IN-PACKAGE :CIM) (MACROLET (#) (IF # # #))))) #<NULL-LEXENV>)
5: (SB-EXT:EVAL-TLF (LET ((SEXPS)) (SETF *ARGV* (PARSE-OPTIONS *RAW-ARGV* (("-c" "--compile") (FILE) "compile FILE." (PUSH # SEXPS)) (("-C") (DIR) "set *default-pathname-defaults* DIR." (LET # #)) (("-d" "--debug") NIL "set debugging flags (push :debug into *features*)" (PUSH # SEXPS)) (("-e" "--eval") (SEXP) "one line of script. Several -e's are allowed. Omit [programfile]" (SETF # #)) (("-f" "--load") (FILE) "load the FILE" (PUSH # SEXPS)) (("-i") (EXT) "edit *argv* files in place and make backup with the extension .EXT" (PUSH # SEXPS)) (("-l") (LIBRARY) "quickload the LIBRARY" (PUSH # SEXPS)) (("-L") (LIBRARY) "quickload and use-package the LIBRARY" (LET # #)) (("-r" "--repl") NIL "run repl" (SETF # T)) (("-q" "--no-init") NIL "do not load $CIM_HOME/init.lisp" (SETF # T)) ...)) (IF (EQUAL *DEFAULT-PATHNAME-DEFAULTS* #P"") (SETF *DEFAULT-PATHNAME-DEFAULTS* (PATHNAME (GETENV "PWD")))) (COND ((OPT :VERSION) (WRITE-LINE (VERSION))) ((OPT :HELP) (WRITE-LINE *HELP*)) (T (UNLESS (OPT :NO-INIT) (LOAD # :VERBOSE NIL :PRINT NIL)) (IN-PACKAGE :CL) (DOLIST (SEXP #) (EVAL SEXP)) (IN-PACKAGE :CIM) (MACROLET (#) (IF # # #))))) 17 #<NULL-LEXENV>)
6: ((FLET SB-FASL::EVAL-FORM :IN SB-INT:LOAD-AS-SOURCE) (LET ((SEXPS)) (SETF *ARGV* (PARSE-OPTIONS *RAW-ARGV* (("-c" "--compile") (FILE) "compile FILE." (PUSH # SEXPS)) (("-C") (DIR) "set *default-pathname-defaults* DIR." (LET # #)) (("-d" "--debug") NIL "set debugging flags (push :debug into *features*)" (PUSH # SEXPS)) (("-e" "--eval") (SEXP) "one line of script. Several -e's are allowed. Omit [programfile]" (SETF # #)) (("-f" "--load") (FILE) "load the FILE" (PUSH # SEXPS)) (("-i") (EXT) "edit *argv* files in place and make backup with the extension .EXT" (PUSH # SEXPS)) (("-l") (LIBRARY) "quickload the LIBRARY" (PUSH # SEXPS)) (("-L") (LIBRARY) "quickload and use-package the LIBRARY" (LET # #)) (("-r" "--repl") NIL "run repl" (SETF # T)) (("-q" "--no-init") NIL "do not load $CIM_HOME/init.lisp" (SETF # T)) ...)) (IF (EQUAL *DEFAULT-PATHNAME-DEFAULTS* #P"") (SETF *DEFAULT-PATHNAME-DEFAULTS* (PATHNAME (GETENV "PWD")))) (COND ((OPT :VERSION) (WRITE-LINE (VERSION))) ((OPT :HELP) (WRITE-LINE *HELP*)) (T (UNLESS (OPT :NO-INIT) (LOAD # :VERBOSE NIL :PRINT NIL)) (IN-PACKAGE :CL) (DOLIST (SEXP #) (EVAL SEXP)) (IN-PACKAGE :CIM) (MACROLET (#) (IF # # #))))) 17)
7: (SB-INT:LOAD-AS-SOURCE #<SB-SYS:FD-STREAM for "file /Users/nitro_idiot/.cim/lib/script.lisp" {1003AC7D23}> :VERBOSE NIL :PRINT NIL :CONTEXT "loading")
8: ((FLET SB-FASL::LOAD-STREAM :IN LOAD) #<SB-SYS:FD-STREAM for "file /Users/nitro_idiot/.cim/lib/script.lisp" {1003AC7D23}> NIL)
9: (LOAD #P"/Users/nitro_idiot/.cim/lib/script.lisp" :VERBOSE NIL :PRINT NIL :IF-DOES-NOT-EXIST T :EXTERNAL-FORMAT :DEFAULT)
10: (SB-IMPL::PROCESS-EVAL/LOAD-OPTIONS ((:LOAD . "/Users/nitro_idiot/.cim/lib/script.lisp") (:QUIT)))
11: (SB-IMPL::TOPLEVEL-INIT)
12: ((FLET #:WITHOUT-INTERRUPTS-BODY-89 :IN SB-EXT:SAVE-LISP-AND-DIE))
13: ((LABELS SB-IMPL::RESTART-LISP :IN SB-EXT:SAVE-LISP-AND-DIE))

unhandled condition in --disable-debugger mode, quitting
```
