### PR TITLE
More portable executable checking with find

### DIFF
--- a/scripts/cim_lib_install
+++ b/scripts/cim_lib_install
@@ -377,7 +377,7 @@ __ccl_rebuild_full(){
         ;;
     esac
 
-    executable=`find "$CIM_HOME/src/$1-$2/" -maxdepth 1 -perm +111 -type f $logic -name '*64' 2> /dev/null ` ||
+    executable=`find "$CIM_HOME/src/$1-$2/" -maxdepth 1 -exec test -x {} \; -type f $logic -name '*64' -print 2> /dev/null ` ||
     return 1
     cim_with_output_control "$1-$2" "build" "$executable" --no-init --eval '(rebuild-ccl :full t)' --eval '(quit)'
     if [ "$?" != "0" ]; then


### PR DESCRIPTION
Hey,

I found that when trying to install CCL on linux with find 4.5.11 it can't find the executable file.  I believe this patch should be more portable as it uses the test command instead.  At some point the + combined with octal permissions was removed from the GNU Find command because it conflicts with the symbolic permission descriptions.  Most people seemed to be quoting 4.5.12 but it didn't work for me on debian sid so who knows.

```
Building ccl-1.10
+ cim_arch
+ uname -m
+ echo intel/64/l
+ find /home/russell/.cim/src/ccl-1.10/ -maxdepth 1 -perm +111 -type f -name *64
+ executable=
+ return 1
+ exit 1
+ rm -f /home/russell/.cim/tmp/ccl-1.10.lock
```