### PR TITLE
Add simple capture of exit codes of commands run.

### DIFF
--- a/scripts/cim_cmd_for
+++ b/scripts/cim_cmd_for
@@ -35,8 +35,13 @@ if [ "$1" != do ];then
 fi
 shift
 
+exit_code=0
+
 for impl in $impls;do
     cim_green ">>>$impl $@"
     LISP_IMPL="$impl" cl "$@"
+    exit_code=`expr $exit_code + $?`
     cim_green "<<<"
 done
+
+exit $exit_code


### PR DESCRIPTION
This lets the user check $? after all implementations are run to see if there were any problems.

Without this change `cim for...` always returns successfully...