### PR TITLE
Evaluate command line options in package CL-USER

### DIFF
--- a/lib/script.lisp
+++ b/lib/script.lisp
@@ -200,7 +200,7 @@
      (write-line *help* ))
     (t
      (unless (opt :no-init) (load (cim_home "/init.lisp") :verbose nil :print nil))
-     (in-package :cl)
+     (in-package :cl-user)
      (handler-case
          (dolist (sexp (nreverse cim::sexps)) 
            (eval sexp))


### PR DESCRIPTION
When they're evaluated in the COMMON-LISP package, issues arise when
anything tries to intern a symbol. This happens on at least CLISP and
ECL. COMMON-LISP-USER is the canonical package for user-specified
expressions to be evaluated, and should be used instead.

Simple failing testcase:

```
cl -e "(defparameter *a* 'a)"
```
